### PR TITLE
Fix: Add cronjobs and refactor code

### DIFF
--- a/charts/librephotos/Chart.lock
+++ b/charts/librephotos/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: postgresql
+  repository: https://charts.bitnami.com/bitnami
+  version: 11.1.28
+- name: redis
+  repository: https://charts.bitnami.com/bitnami
+  version: 16.9.1
+digest: sha256:c1ae94be7fad2f0e3d9535bdbf07a1a2304b4062070517c969703d6d7d9e3e07
+generated: "2022-05-10T14:16:10.047409+02:00"

--- a/charts/librephotos/Chart.yaml
+++ b/charts/librephotos/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: librephotos
 description: Helmchart used to install Librephotos in a microservice manner
-version: 0.202215.1
+version: 0.202215.2
 appVersion: 2022w15
 home: https://github.com/varet80/publiccharts/tree/main/charts/librephotos
 kubeVersion: '>=1.21.0-0'

--- a/charts/librephotos/README.md
+++ b/charts/librephotos/README.md
@@ -1,6 +1,6 @@
 # librephotos
 
-![Version: 0.202215.0](https://img.shields.io/badge/Version-0.202215.0-informational?style=flat-square) ![AppVersion: 2022w15](https://img.shields.io/badge/AppVersion-2022w15-informational?style=flat-square)
+![Version: 0.202215.2](https://img.shields.io/badge/Version-0.202215.2-informational?style=flat-square) ![AppVersion: 2022w15](https://img.shields.io/badge/AppVersion-2022w15-informational?style=flat-square)
 
 Helmchart used to install Librephotos in a microservice manner
 
@@ -10,7 +10,7 @@ Helmchart used to install Librephotos in a microservice manner
 
 | Name | Email | Url |
 | ---- | ------ | --- |
-| varet |  | <https://github.com/varet80> |
+| Vassilis Aretakis |  | <https://github.com/varet80> |
 
 ## Source Code
 
@@ -30,7 +30,7 @@ Kubernetes: `>=1.21.0-0`
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| backend | object | `{"annotations":{},"env":{"ALLOW_UPLOAD":"false","DB_BACKEND":"postgresql","DEBUG":"0","HEAVYWEIGHT_PROCESS":"2","SKIP_PATTERNS":"","WEB_CONCURRENCY":"4"},"envTemplates":{"dbName":"{{ .Values.postgresql.auth.database }}","dbPort":"{{ .Values.postgresql.containerPorts.postgresql }}","dbUser":"{{ .Values.postgresql.auth.database }}","redisPort":"{{ .Values.redis.master.containerPorts.redis }}"},"healthchecks":{"livenessProbe":{"failureThreshold":5,"initialDelaySeconds":10,"periodSeconds":120,"tcpSocket":{"port":8001},"timeoutSeconds":5},"readinessProbe":{"failureThreshold":5,"initialDelaySeconds":10,"periodSeconds":120,"tcpSocket":{"port":8001},"timeoutSeconds":5},"startupProbe":{"failureThreshold":60,"initialDelaySeconds":10,"periodSeconds":5,"tcpSocket":{"port":8001},"timeoutSeconds":2}},"image":{"repository":"reallibrephotos/librephotos"},"replicaCount":1,"resources":{"limits":{"cpu":"4000m","memory":"8Gi"},"requests":{"cpu":"10m","memory":"50Mi"}}}` | Configurationf or the Backend services |
+| backend | object | `{"annotations":{},"env":{"ALLOW_UPLOAD":"false","DB_BACKEND":"postgresql","DEBUG":"0","HEAVYWEIGHT_PROCESS":"2","SKIP_PATTERNS":"","WEB_CONCURRENCY":"4"},"envTemplates":{"dbName":"{{ .Values.postgresql.auth.database }}","dbPort":"{{ .Values.postgresql.containerPorts.postgresql }}","dbUser":"{{ .Values.postgresql.auth.database }}","redisPort":"{{ .Values.redis.master.containerPorts.redis }}"},"healthchecks":{"livenessProbe":{"failureThreshold":5,"initialDelaySeconds":10,"periodSeconds":120,"tcpSocket":{"port":8001},"timeoutSeconds":5},"readinessProbe":{"failureThreshold":5,"initialDelaySeconds":10,"periodSeconds":120,"tcpSocket":{"port":8001},"timeoutSeconds":5},"startupProbe":{"failureThreshold":60,"initialDelaySeconds":10,"periodSeconds":5,"tcpSocket":{"port":8001},"timeoutSeconds":2}},"image":{"repository":"reallibrephotos/librephotos"},"replicaCount":1,"resources":{"limits":{"memory":"8Gi"},"requests":{"cpu":"10m","memory":"50Mi"}}}` | Configurationf or the Backend services |
 | backend.annotations | object | `{}` | Annotations |
 | backend.envTemplates.dbName | string | `"{{ .Values.postgresql.auth.database }}"` | Postgresql DB Name |
 | backend.envTemplates.dbPort | string | `"{{ .Values.postgresql.containerPorts.postgresql }}"` | Postgresql DB port |
@@ -38,18 +38,38 @@ Kubernetes: `>=1.21.0-0`
 | backend.envTemplates.redisPort | string | `"{{ .Values.redis.master.containerPorts.redis }}"` | redis port retrieved by parent helm chart |
 | backend.image.repository | string | `"reallibrephotos/librephotos"` | Repository and image name |
 | backend.replicaCount | int | `1` | Replica counts |
+| cronjob.native.concurrencyPolicy | string | `"Forbid"` | concurrency policy, Forbid as default, to avoid running two scans |
+| cronjob.native.failedJobsHistoryLimit | int | `10` | keep 10 jobs for log parsing (if they fail |
+| cronjob.native.image.imagePullPolicy | string | `"IfNotPresent"` |  |
+| cronjob.native.image.kubernetesVersion | string | `"1.22.6"` | Check alpine image for the latest available https://hub.docker.com/r/alpine/k8s/tags |
+| cronjob.native.schedule | string | `"0 * * * *"` | Cronjob schedule |
+| cronjob.native.successfulJobHistoryLimit | int | `5` | keep 5 successful jobs for log parsing. |
+| cronjob.native.suspend | bool | `true` | suspension is enabled, to avoid scheduling waiting jobs while scan takes hours! |
+| cronjob.type | string | `"native"` | Create a native kubernetes cronjob, using roles to access kubernetes exec and execute the python through a third party container. This is an Antipattern! but the only way, till another exists |
 | dataVolume.accessModes | list | `["ReadWriteOnce"]` | Access mode of volume |
 | dataVolume.size | string | `"100Gi"` | Size of the volume to be created (data) |
 | dataVolume.stroageClass | string | `""` | Storage class of data volume |
 | extraVolumeMounts | string | `nil` | You can define extra volume mounts, in the typical K8s syntax (Only in backend) |
 | extraVolumes | string | `nil` | You can define extra volumes, in the typical K8s syntax (Only in backend) |
 | frontend.annotations | object | `{}` |  |
+| frontend.healthchecks.livenessProbe.failureThreshold | int | `5` |  |
+| frontend.healthchecks.livenessProbe.initialDelaySeconds | int | `10` |  |
+| frontend.healthchecks.livenessProbe.periodSeconds | int | `120` |  |
+| frontend.healthchecks.livenessProbe.tcpSocket.port | int | `3000` |  |
+| frontend.healthchecks.livenessProbe.timeoutSeconds | int | `5` |  |
+| frontend.healthchecks.readinessProbe.failureThreshold | int | `5` |  |
+| frontend.healthchecks.readinessProbe.initialDelaySeconds | int | `10` |  |
+| frontend.healthchecks.readinessProbe.periodSeconds | int | `120` |  |
+| frontend.healthchecks.readinessProbe.tcpSocket.port | int | `3000` |  |
+| frontend.healthchecks.readinessProbe.timeoutSeconds | int | `5` |  |
+| frontend.healthchecks.startupProbe.failureThreshold | int | `60` |  |
+| frontend.healthchecks.startupProbe.initialDelaySeconds | int | `10` |  |
+| frontend.healthchecks.startupProbe.periodSeconds | int | `5` |  |
+| frontend.healthchecks.startupProbe.tcpSocket.port | int | `3000` |  |
+| frontend.healthchecks.startupProbe.timeoutSeconds | int | `2` |  |
 | frontend.image.repository | string | `"reallibrephotos/librephotos-frontend"` |  |
 | frontend.replicaCount | int | `1` |  |
 | fullnameOverride | string | `""` |  |
-| image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"nginx"` |  |
-| image.tag | string | `""` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.enabled | bool | `false` | enable ingress  |
 | ingress.hostname | string | `""` | currently only hotsname is needed for ingress |
@@ -58,6 +78,24 @@ Kubernetes: `>=1.21.0-0`
 | postgresql.auth.username | string | `"librephotos"` |  |
 | postgresql.enabled | bool | `true` | install bitnami postgresql |
 | proxy.annotations | object | `{}` |  |
+| proxy.healthchecks.livenessProbe.failureThreshold | int | `5` |  |
+| proxy.healthchecks.livenessProbe.httpGet.path | string | `"/protected_media/"` |  |
+| proxy.healthchecks.livenessProbe.httpGet.port | int | `80` |  |
+| proxy.healthchecks.livenessProbe.initialDelaySeconds | int | `10` |  |
+| proxy.healthchecks.livenessProbe.periodSeconds | int | `60` |  |
+| proxy.healthchecks.livenessProbe.timeoutSeconds | int | `5` |  |
+| proxy.healthchecks.readinessProbe.failureThreshold | int | `5` |  |
+| proxy.healthchecks.readinessProbe.httpGet.path | string | `"/protected_media/"` |  |
+| proxy.healthchecks.readinessProbe.httpGet.port | int | `80` |  |
+| proxy.healthchecks.readinessProbe.initialDelaySeconds | int | `10` |  |
+| proxy.healthchecks.readinessProbe.periodSeconds | int | `60` |  |
+| proxy.healthchecks.readinessProbe.timeoutSeconds | int | `5` |  |
+| proxy.healthchecks.startupProbe.failureThreshold | int | `60` |  |
+| proxy.healthchecks.startupProbe.httpGet.path | string | `"/protected_media/"` |  |
+| proxy.healthchecks.startupProbe.httpGet.port | int | `80` |  |
+| proxy.healthchecks.startupProbe.initialDelaySeconds | int | `10` |  |
+| proxy.healthchecks.startupProbe.periodSeconds | int | `5` |  |
+| proxy.healthchecks.startupProbe.timeoutSeconds | int | `2` |  |
 | proxy.image.repository | string | `"reallibrephotos/librephotos-proxy"` |  |
 | proxy.replicaCount | int | `1` |  |
 | redis.architecture | string | `"standalone"` |  |

--- a/charts/librephotos/templates/configmap.yaml
+++ b/charts/librephotos/templates/configmap.yaml
@@ -30,7 +30,7 @@ data:
         location ~ ^/(api|media)/ {
           proxy_set_header X-Forwarded-Proto $scheme;
           proxy_set_header X-Real-IP $remote_addr;
-          proxy_set_header Host localhost;
+          proxy_set_header Host {{ $resourceName }}-backend;
           include uwsgi_params;
           proxy_pass http://{{ $resourceName }}-backend;
         }

--- a/charts/librephotos/templates/cronjob-native/configmap.yaml
+++ b/charts/librephotos/templates/cronjob-native/configmap.yaml
@@ -1,0 +1,10 @@
+{{- if eq .cronjob.type "native" }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "names.name" }}-scan-cron
+data:
+  cronjob.sh: |
+    POD=$(kubectl get pods -n nextcloud -l app.kubernetes.io/name={{ include "names.name" . }},app.kubernetes.io/instance={{ .Release.Name }},app.kubernetes.io/app=backend --no-headers -o custom-columns=NAME:.metadata.name |head)
+    kubectl exec $POD -ti -- /bin/sh -c "cd /code; python3 manage.py scan"
+{{- end }}

--- a/charts/librephotos/templates/cronjob-native/configmap.yaml
+++ b/charts/librephotos/templates/cronjob-native/configmap.yaml
@@ -1,8 +1,8 @@
-{{- if eq .cronjob.type "native" }}
+{{- if eq .Values.cronjob.type "native" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "names.name" }}-scan-cron
+  name: {{ include "names.name" . }}-scan-cron
 data:
   cronjob.sh: |
     POD=$(kubectl get pods -n nextcloud -l app.kubernetes.io/name={{ include "names.name" . }},app.kubernetes.io/instance={{ .Release.Name }},app.kubernetes.io/app=backend --no-headers -o custom-columns=NAME:.metadata.name |head)

--- a/charts/librephotos/templates/cronjob-native/cronjob.yaml
+++ b/charts/librephotos/templates/cronjob-native/cronjob.yaml
@@ -1,0 +1,43 @@
+{{- if eq .cronjob.type "native" }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "names.name" }}-scan-cron
+  labels:
+    app.kubernetes.io/app: scan-cron
+    {{- include "names.name" . | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.cronjob.native.annotations | indent 4 }}
+spec:
+  schedule: "{{ .Values.cronjob.native.schedule }}"
+  concurrencyPolicy: {{ .Values.cronjob.native.concurrencyPolicy }}
+  suspend: {{ .Values.cronjob.native.suspend }}
+  failedJobsHistoryLimit: {{ .Values.cronjob.native.failedJobsHistoryLimit }}
+  successfulJobsHistoryLimit: {{ .Values.cronjob.native.successfulJobsHistoryLimit }}
+  jobTemplate:
+    metadata:
+      labels:
+        app.kubernetes.io/app: scan-cron
+        {{- include "names.name" . | nindent 8 }}
+    spec:
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/app: scan-cron
+            {{- include "names.name" . | nindent 12 }}
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: {{ .Chart.Name }}
+              image: alpine/k8s:{{ .Values.cronjob.native.image.kubernetesVersion }}
+              imagePullPolicy: {{ .Values.cronjob.native.image.pullPolicy }}
+              volumeMounts:
+              - name: backend-cj-script
+                mountPath: /opt
+              command:  [ "/bin/sh", "/opt/cronjob.sh"]
+          serviceAccountName: nextcloud-cron
+          volumes:
+          - name: backend-cj-script
+            configMap:
+              name: {{ .Release.Name }}-scan-cron
+{{- end }}

--- a/charts/librephotos/templates/cronjob-native/cronjob.yaml
+++ b/charts/librephotos/templates/cronjob-native/cronjob.yaml
@@ -36,7 +36,7 @@ spec:
               - name: backend-cj-script
                 mountPath: /opt
               command:  [ "/bin/sh", "/opt/cronjob.sh"]
-          serviceAccountName: nextcloud-cron
+          serviceAccountName: {{ .Release.Name }}-scan-cron
           volumes:
           - name: backend-cj-script
             configMap:

--- a/charts/librephotos/templates/cronjob-native/cronjob.yaml
+++ b/charts/librephotos/templates/cronjob-native/cronjob.yaml
@@ -6,9 +6,9 @@ metadata:
   name: {{ include "names.name" . }}-scan-cron
   labels:
     app.kubernetes.io/app: scan-cron
-    {{- include "names.name" . | nindent 4 }}
+    {{- include "labels" . | nindent 4 }}
   annotations:
-    {{- toYaml $localTree.annotations | indent 4 }}
+    {{ toYaml $localTree.annotations | indent 4 }}
 spec:
   schedule: "{{ $localTree.schedule }}"
   concurrencyPolicy: {{ $localTree.concurrencyPolicy }}
@@ -19,13 +19,13 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/app: scan-cron
-        {{- include "names.name" . | nindent 8 }}
+        {{- include "labels.selectorLabels" . | nindent 8 }}
     spec:
       template:
         metadata:
           labels:
             app.kubernetes.io/app: scan-cron
-            {{- include "names.name" . | nindent 12 }}
+            {{- include "labels.selectorLabels" . | nindent 12 }}
         spec:
           restartPolicy: Never
           containers:

--- a/charts/librephotos/templates/cronjob-native/cronjob.yaml
+++ b/charts/librephotos/templates/cronjob-native/cronjob.yaml
@@ -1,19 +1,20 @@
-{{- if eq .cronjob.type "native" }}
+{{- if eq .Values.cronjob.type "native" }}
+{{ $localTree := .Values.cronjob.native }}
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: {{ include "names.name" }}-scan-cron
+  name: {{ include "names.name" . }}-scan-cron
   labels:
     app.kubernetes.io/app: scan-cron
     {{- include "names.name" . | nindent 4 }}
   annotations:
-    {{- toYaml .Values.cronjob.native.annotations | indent 4 }}
+    {{- toYaml $localTree.annotations | indent 4 }}
 spec:
-  schedule: "{{ .Values.cronjob.native.schedule }}"
-  concurrencyPolicy: {{ .Values.cronjob.native.concurrencyPolicy }}
-  suspend: {{ .Values.cronjob.native.suspend }}
-  failedJobsHistoryLimit: {{ .Values.cronjob.native.failedJobsHistoryLimit }}
-  successfulJobsHistoryLimit: {{ .Values.cronjob.native.successfulJobsHistoryLimit }}
+  schedule: "{{ $localTree.schedule }}"
+  concurrencyPolicy: {{ $localTree.concurrencyPolicy }}
+  suspend: {{ $localTree.suspend }}
+  failedJobsHistoryLimit: {{ $localTree.failedJobsHistoryLimit }}
+  successfulJobsHistoryLimit: {{ $localTree.successfulJobsHistoryLimit }}
   jobTemplate:
     metadata:
       labels:
@@ -29,8 +30,8 @@ spec:
           restartPolicy: Never
           containers:
             - name: {{ .Chart.Name }}
-              image: alpine/k8s:{{ .Values.cronjob.native.image.kubernetesVersion }}
-              imagePullPolicy: {{ .Values.cronjob.native.image.pullPolicy }}
+              image: alpine/k8s:{{ $localTree.image.kubernetesVersion }}
+              imagePullPolicy: {{ $localTree.image.pullPolicy }}
               volumeMounts:
               - name: backend-cj-script
                 mountPath: /opt

--- a/charts/librephotos/templates/cronjob-native/role-cronjob.yaml
+++ b/charts/librephotos/templates/cronjob-native/role-cronjob.yaml
@@ -1,0 +1,13 @@
+{{- if eq .cronjob.type "native" }}
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "names.name" }}-scan-cron
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list"]
+- apiGroups: [""]
+  resources: ["pods/exec"]
+  verbs: ["create"]
+{{- end }}

--- a/charts/librephotos/templates/cronjob-native/role-cronjob.yaml
+++ b/charts/librephotos/templates/cronjob-native/role-cronjob.yaml
@@ -1,8 +1,8 @@
-{{- if eq .cronjob.type "native" }}
+{{- if eq .Values.cronjob.type "native" }}
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ include "names.name" }}-scan-cron
+  name: {{ include "names.name" . }}-scan-cron
 rules:
 - apiGroups: [""]
   resources: ["pods"]

--- a/charts/librephotos/templates/cronjob-native/rolebinding-cronjob.yaml
+++ b/charts/librephotos/templates/cronjob-native/rolebinding-cronjob.yaml
@@ -1,0 +1,13 @@
+{{- if eq .cronjob.type "native" }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "names.name" }}-scan-cron
+subjects:
+- kind: ServiceAccount
+  name: {{ include "names.name" }}-scan-cron
+roleRef:
+  kind: Role
+  name:  {{ include "names.name" }}-scan-cron
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/librephotos/templates/cronjob-native/rolebinding-cronjob.yaml
+++ b/charts/librephotos/templates/cronjob-native/rolebinding-cronjob.yaml
@@ -1,13 +1,13 @@
-{{- if eq .cronjob.type "native" }}
+{{- if eq .Values.cronjob.type "native" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ include "names.name" }}-scan-cron
+  name: {{ include "names.name" . }}-scan-cron
 subjects:
 - kind: ServiceAccount
-  name: {{ include "names.name" }}-scan-cron
+  name: {{ include "names.name" . }}-scan-cron
 roleRef:
   kind: Role
-  name:  {{ include "names.name" }}-scan-cron
+  name:  {{ include "names.name" . }}-scan-cron
   apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/charts/librephotos/templates/cronjob-native/serviceaccount-cronjob.yaml
+++ b/charts/librephotos/templates/cronjob-native/serviceaccount-cronjob.yaml
@@ -1,6 +1,6 @@
-{{- if eq .cronjob.type "native" }}
+{{- if eq .Values.cronjob.type "native" }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "names.name" }}-scan-cron
+  name: {{ include "names.name" . }}-scan-cron
 {{- end }}

--- a/charts/librephotos/templates/cronjob-native/serviceaccount-cronjob.yaml
+++ b/charts/librephotos/templates/cronjob-native/serviceaccount-cronjob.yaml
@@ -1,0 +1,6 @@
+{{- if eq .cronjob.type "native" }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "names.name" }}-scan-cron
+{{- end }}

--- a/charts/librephotos/templates/deploymentBackend.yaml
+++ b/charts/librephotos/templates/deploymentBackend.yaml
@@ -1,5 +1,6 @@
 {{- $resourceName := .Release.Name }}
 {{- $selectorLabels := include "labels.selectorLabels" . }}
+{{ $localTree := .Values.backend }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -8,12 +9,12 @@ metadata:
     app.kubernetes.io/app: backend
     {{- include "labels" .| nindent 4 }}
   annotations:
-    {{- toYaml .Values.backend.annotations | nindent 4 }}
+    {{- toYaml $localTree.annotations | nindent 4 }}
 spec:
   revisionHistoryLimit: 3
-  replicas: {{ .Values.backend.replicaCount }}
+  replicas: {{ $localTree.replicaCount }}
   strategy:
-    type: Recreate
+    type: {{ $localTree.updateStrategyType }}
   selector:
     matchLabels:
       app.kubernetes.io/app: backend
@@ -21,7 +22,7 @@ spec:
   template:
     metadata:
       annotations:
-        {{- toYaml .Values.backend.annotations | nindent 8 }}
+        {{- toYaml $localTree.annotations | nindent 8 }}
       labels:
         app.kubernetes.io/app: backend
         {{-  $selectorLabels | nindent 8 }}
@@ -29,8 +30,8 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: photos-librephotos
-          image: "{{ .Values.backend.image.repository }}:{{ default .Chart.AppVersion .Values.backend.image.tag }}"
-          imagePullPolicy: {{ default "IfNotPresent" .Values.backend.image.pullPolicy }}
+          image: "{{ $localTree.image.repository }}:{{ default .Chart.AppVersion $localTree.image.tag }}"
+          imagePullPolicy: {{ default "IfNotPresent" $localTree.image.pullPolicy }}
           tty: false
           stdin: false
           securityContext:
@@ -38,18 +39,18 @@ spec:
           env:
             - name: "BACKEND_HOST"
               value: "{{ $resourceName }}-backend"
-            {{- range $k, $v := .Values.backend.env }}
+            {{- range $k, $v := $localTree.env }}
             - name: "{{ $k }}"
               value: "{{ $v }}"
             {{- end }}
             - name: "REDIS_PORT"
-              value: {{ tpl .Values.backend.envTemplates.redisPort . | quote }}
+              value: {{ tpl $localTree.envTemplates.redisPort . | quote }}
             - name: "DB_NAME"
-              value: {{ tpl .Values.backend.envTemplates.dbName . }}
+              value: {{ tpl $localTree.envTemplates.dbName . }}
             - name: "DB_PORT"
-              value: {{ tpl .Values.backend.envTemplates.dbPort . | quote }}
+              value: {{ tpl $localTree.envTemplates.dbPort . | quote }}
             - name: "DB_USER"
-              value: {{ tpl .Values.backend.envTemplates.dbUser . }}
+              value: {{ tpl $localTree.envTemplates.dbUser . }}
             - name: DB_HOST
               value: {{ $resourceName }}-postgresql
             - name: DB_PASS
@@ -98,10 +99,10 @@ spec:
             - mountPath: /var/logs
               name: varlogs
             {{- if .Values.extraVolumeMounts }}{{- toYaml .Values.extraVolumeMounts | nindent 12 }}{{- end }}
-          {{- toYaml .Values.backend.healthchecks | nindent 10 }}
-          {{- if .Values.backend.resources }}
+          {{- toYaml $localTree.healthchecks | nindent 10 }}
+          {{- if $localTree.resources }}
           resources:
-            {{- toYaml .Values.backend.resources | nindent 12 }}
+            {{- toYaml $localTree.resources | nindent 12 }}
           {{- end }}
       volumes:
         {{- toYaml .Values.volumes | nindent 8 }}

--- a/charts/librephotos/templates/deploymentFrontend.yaml
+++ b/charts/librephotos/templates/deploymentFrontend.yaml
@@ -1,4 +1,5 @@
 {{ $resourceName := .Release.Name }}
+{{ $localTree := .Values.frontend }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -6,12 +7,12 @@ metadata:
   labels:
     {{- include "labels" .| nindent 4 }}
   annotations:
-    {{- toYaml .Values.frontend.annotations | nindent 4 }}
+    {{- toYaml $localTree.annotations | nindent 4 }}
 spec:
   revisionHistoryLimit: 3
-  replicas: {{ .Values.frontend.replicaCount }}
+  replicas: {{ $localTree.replicaCount }}
   strategy:
-    type: Recreate
+    type: {{ $localTree.updateStrategyType }}
   selector:
     matchLabels:
       app.kubernetes.io/app: frontend
@@ -19,7 +20,7 @@ spec:
   template:
     metadata:
       annotations:
-        {{- toYaml .Values.frontend.annotations | nindent 8 }}
+        {{- toYaml $localTree.annotations | nindent 8 }}
       labels:
         app.kubernetes.io/app: frontend
         {{- include "labels.selectorLabels" .| nindent 8 }}
@@ -27,17 +28,18 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: frontend
-          image: "{{ .Values.frontend.image.repository }}:{{ default .Chart.AppVersion .Values.frontend.image.tag }}"
-          imagePullPolicy: {{ default "IfNotPresent" .Values.frontend.image.pullPolicy }}
+          image: "{{ $localTree.image.repository }}:{{ default .Chart.AppVersion $localTree.image.tag }}"
+          imagePullPolicy: {{ default "IfNotPresent" $localTree.image.pullPolicy }}
           tty: false
           stdin: false
+          {{- toYaml $localTree.healthchecks | nindent 10 }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           ports:
             - name: frontend
               containerPort: 3000
               protocol: TCP
-          {{- if .Values.frontend.resources }}
+          {{- if $localTree.resources }}
           resources:
-            {{- toYaml .Values.frontend.resources | nindent 12 }}
+            {{- toYaml $localTree.resources | nindent 12 }}
           {{- end }}

--- a/charts/librephotos/templates/deploymentProxy.yaml
+++ b/charts/librephotos/templates/deploymentProxy.yaml
@@ -1,5 +1,5 @@
 {{ $resourceName := .Release.Name }}
-{{ localTree := .Values.proxy }}
+{{ $localTree := .Values.proxy }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -12,7 +12,7 @@ spec:
   revisionHistoryLimit: 3
   replicas: {{ $localTree.replicaCount }}
   strategy:
-    type: {{ $localValues.updateStrategyType }}
+    type: {{ $localTree.updateStrategyType }}
   selector:
     matchLabels:
       app.kubernetes.io/app: proxy

--- a/charts/librephotos/templates/deploymentProxy.yaml
+++ b/charts/librephotos/templates/deploymentProxy.yaml
@@ -1,4 +1,5 @@
 {{ $resourceName := .Release.Name }}
+{{ localTree := .Values.proxy }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -6,12 +7,12 @@ metadata:
   labels:
     {{- include "labels" .| nindent 4 }}
   annotations:
-    {{- toYaml .Values.proxy.annotations | nindent 4 }}
+    {{- toYaml $localTree.annotations | nindent 4 }}
 spec:
   revisionHistoryLimit: 3
-  replicas: {{ .Values.proxy.replicaCount }}
+  replicas: {{ $localTree.replicaCount }}
   strategy:
-    type: Recreate
+    type: {{ $localValues.updateStrategyType }}
   selector:
     matchLabels:
       app.kubernetes.io/app: proxy
@@ -19,7 +20,7 @@ spec:
   template:
     metadata:
       annotations:
-        {{- toYaml .Values.proxy.annotations | nindent 8 }}
+        {{- toYaml $localTree.annotations | nindent 8 }}
       labels:
         app.kubernetes.io/app: proxy
         {{- include "labels.selectorLabels" .| nindent 8 }}
@@ -27,8 +28,9 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: proxy
-          image: "{{ .Values.proxy.image.repository }}:{{ default .Chart.AppVersion .Values.proxy.image.tag }}"
-          imagePullPolicy: {{ default "IfNotPresent" .Values.proxy.image.pullPolicy }}
+          image: "{{ $localTree.image.repository }}:{{ default .Chart.AppVersion $localTree.image.tag }}"
+          imagePullPolicy: {{ default "IfNotPresent" $localTree.image.pullPolicy }}
+          {{- toYaml $localTree.healthchecks | nindent 10 }}
           tty: false
           stdin: false
           securityContext:
@@ -51,9 +53,9 @@ spec:
             - mountPath: /protected_media
               name: data
               subPath: protected-media
-          {{- if .Values.proxy.resources }}
+          {{- if $localTree.resources }}
           resources:
-            {{- toYaml .Values.proxy.resources | nindent 12 }}
+            {{- toYaml $localTree.resources | nindent 12 }}
           {{- end }}
       volumes:
         - name: data

--- a/charts/librephotos/values.yaml
+++ b/charts/librephotos/values.yaml
@@ -9,7 +9,6 @@ backend:
     repository: reallibrephotos/librephotos
   resources:
     limits:
-      cpu: 4000m
       memory: 8Gi
     requests:
       cpu: 10m
@@ -58,16 +57,58 @@ frontend:
   annotations: {}
   image:
     repository: reallibrephotos/librephotos-frontend
+  healthchecks:
+    livenessProbe:
+      tcpSocket:
+        port: 3000
+      initialDelaySeconds: 10
+      failureThreshold: 5
+      timeoutSeconds: 5
+      periodSeconds: 120
+    readinessProbe:
+      tcpSocket:
+        port: 3000
+      initialDelaySeconds: 10
+      failureThreshold: 5
+      timeoutSeconds: 5
+      periodSeconds: 120
+    startupProbe:
+      tcpSocket:
+        port: 3000
+      initialDelaySeconds: 10
+      failureThreshold: 60
+      timeoutSeconds: 2
+      periodSeconds: 5
 proxy:
   replicaCount: 1
   annotations: {}
   image:
     repository: reallibrephotos/librephotos-proxy
-image:
-  repository: nginx
-  pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
-  tag: ""
+  healthchecks:
+    livenessProbe:
+      httpGet:
+        path: /protected_media/
+        port: 80 
+      initialDelaySeconds: 10
+      failureThreshold: 5
+      timeoutSeconds: 5
+      periodSeconds: 60
+    readinessProbe:
+      httpGet:
+        path: /protected_media/
+        port: 80 
+      initialDelaySeconds: 10
+      failureThreshold: 5
+      timeoutSeconds: 5
+      periodSeconds: 60
+    startupProbe:
+      httpGet:
+        path: /protected_media/
+        port: 80 
+      initialDelaySeconds: 10
+      failureThreshold: 60
+      timeoutSeconds: 2
+      periodSeconds: 5
 
 service:
   backend:
@@ -100,6 +141,23 @@ secret:
   ADMIN_USERNAME: "admin"
   ADMIN_PASSWORD: "password"
   MAPBOX_API_KEY: ""
+
+cronjob:
+  # -- Create a native kubernetes cronjob, using roles to access kubernetes exec and execute the python through a third party container. This is an Antipattern! but the only way, till another exists
+  type: native
+  native:
+    # -- Cronjob schedule
+    schedule: "0 * * * *"
+    # -- concurrency policy, Forbid as default, to avoid running two scans
+    concurrencyPolicy: Forbid
+    # -- suspension is enabled, to avoid scheduling waiting jobs while scan takes hours!
+    suspend: true
+    # -- keep 10 jobs for log parsing (if they fail
+    failedJobsHistoryLimit: 10
+    # -- keep 5 successful jobs for log parsing.
+    successfulJobHistoryLimit: 5
+    image: IfNotPresent
+    kubernetesVersion: "1.22.6"
 
 nameOverride: ""
 fullnameOverride: ""

--- a/charts/librephotos/values.yaml
+++ b/charts/librephotos/values.yaml
@@ -4,7 +4,7 @@ backend:
   replicaCount: 1
   # -- Annotations
   annotations: {}
-  strategyType: Recreate
+  updateStrategy: Recreate
   image:
     # -- Repository and image name
     repository: reallibrephotos/librephotos
@@ -55,7 +55,7 @@ backend:
 
 frontend:
   replicaCount: 1
-  strategyType: RollingUpdate
+  updateStrategy: RollingUpdate
   annotations: {}
   image:
     repository: reallibrephotos/librephotos-frontend
@@ -83,7 +83,7 @@ frontend:
       periodSeconds: 5
 proxy:
   replicaCount: 1
-  strategyType: RollingUpdate
+  updateStrategy: RollingUpdate
   annotations: {}
   image:
     repository: reallibrephotos/librephotos-proxy

--- a/charts/librephotos/values.yaml
+++ b/charts/librephotos/values.yaml
@@ -146,6 +146,8 @@ cronjob:
   # -- Create a native kubernetes cronjob, using roles to access kubernetes exec and execute the python through a third party container. This is an Antipattern! but the only way, till another exists
   type: native
   native:
+    # -- Annotations for the cronjog
+    annotations: {}
     # -- Cronjob schedule
     schedule: "0 * * * *"
     # -- concurrency policy, Forbid as default, to avoid running two scans

--- a/charts/librephotos/values.yaml
+++ b/charts/librephotos/values.yaml
@@ -4,6 +4,7 @@ backend:
   replicaCount: 1
   # -- Annotations
   annotations: {}
+  strategyType: Recreate
   image:
     # -- Repository and image name
     repository: reallibrephotos/librephotos
@@ -54,6 +55,7 @@ backend:
 
 frontend:
   replicaCount: 1
+  strategyType: RollingUpdate
   annotations: {}
   image:
     repository: reallibrephotos/librephotos-frontend
@@ -81,29 +83,27 @@ frontend:
       periodSeconds: 5
 proxy:
   replicaCount: 1
+  strategyType: RollingUpdate
   annotations: {}
   image:
     repository: reallibrephotos/librephotos-proxy
   healthchecks:
     livenessProbe:
-      httpGet:
-        path: /protected_media/
+      tcpSocket:
         port: 80 
       initialDelaySeconds: 10
       failureThreshold: 5
       timeoutSeconds: 5
       periodSeconds: 60
     readinessProbe:
-      httpGet:
-        path: /protected_media/
+      tcpSocker:
         port: 80 
       initialDelaySeconds: 10
       failureThreshold: 5
       timeoutSeconds: 5
       periodSeconds: 60
     startupProbe:
-      httpGet:
-        path: /protected_media/
+      tcpSocket:
         port: 80 
       initialDelaySeconds: 10
       failureThreshold: 60

--- a/charts/librephotos/values.yaml
+++ b/charts/librephotos/values.yaml
@@ -96,7 +96,7 @@ proxy:
       timeoutSeconds: 5
       periodSeconds: 60
     readinessProbe:
-      tcpSocker:
+      tcpSocket:
         port: 80 
       initialDelaySeconds: 10
       failureThreshold: 5

--- a/charts/librephotos/values.yaml
+++ b/charts/librephotos/values.yaml
@@ -156,8 +156,10 @@ cronjob:
     failedJobsHistoryLimit: 10
     # -- keep 5 successful jobs for log parsing.
     successfulJobHistoryLimit: 5
-    image: IfNotPresent
-    kubernetesVersion: "1.22.6"
+    image:
+      imagePullPolicy: IfNotPresent
+      # -- Check alpine image for the latest available https://hub.docker.com/r/alpine/k8s/tags
+      kubernetesVersion: "1.22.6"
 
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
Added cronjob support, using native kubernetes cronjobs
- It can be considered antipattern, but the only way to execute a scan is by executing a command in the shell of the backend container (for the moment)

Refactored parts of code, to be easier to extend